### PR TITLE
Fix typos

### DIFF
--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -90,7 +90,7 @@ search <query>
 
 seek <position>             
 	Seek to position. The position is expressed in [+-][[hh:]:mm]:ss format. If
-	+ or - is used, the seek is done relative to the current positon.
+	+ or - is used, the seek is done relative to the current position.
 
 status
 	Display MPD status.

--- a/davis.1
+++ b/davis.1
@@ -144,7 +144,7 @@ the format.\&
 seek <position>             
 .RS 4
 Seek to position.\& The position is expressed in [+-][[hh:]:mm]:ss format.\& If
-+ or - is used, the seek is done relative to the current positon.\&
++ or - is used, the seek is done relative to the current position.\&
 .P
 .RE
 status

--- a/src/error.rs
+++ b/src/error.rs
@@ -41,7 +41,7 @@ impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Error::Mpd(e) => {
-                write!(f, "An error occured when communicating with MPD:\n{}", e)
+                write!(f, "An error occurred when communicating with MPD:\n{}", e)
             }
             Error::Io { error, context } => {
                 write!(f, "I/O error when {}:\n{}", context, error)

--- a/subcommands/cover/README.md
+++ b/subcommands/cover/README.md
@@ -1,4 +1,4 @@
 # davis-cover
 `davis-cover` uses [picat](https://github.com/SimonPersson/picat) to display
-album art as high quality sixel grapics. Not every terminal supports sixels, I
+album art as high quality sixel graphics. Not every terminal supports sixels, I
 have personally tested this on xterm and [foot](https://codeberg.org/dnkl/foot).


### PR DESCRIPTION
Found via `codespell -L crate,bu`.