### PR TITLE
Fix markdowns

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 Davis is a [MPD](https://www.musicpd.org/) client for music lovers.
 
-### Davis displays detailed metadata:
+## Features
+
+### Davis displays detailed metadata
+
 Davis displays any metadata you like! The performers, conductor, ensemble,
 work, movement, recording location, etc., can all be displayed so long as it's
 in your tags:
 ![screenshot of davis current](scrots/current.png)
 
 ### Davis supports album art
+
 Davis can fetch album art directly from MPD, using the `albumart` command of
 the MPD protocol. This means that davis can fetch album art even from remote
 MPD instances, and does not need to know the location of your music directory.
@@ -17,21 +21,26 @@ possible to display the album art as sixel graphics in the terminal:
 ![screenshot of davis cover](scrots/cur.png)
 
 ### Davis understands classical music
+
 Davis will group your queue by work, and displays movement tags instead of title:
 ![screenshot of davis queue](scrots/queue.png)
 
 ### Custom subcommands
+
 Davis can be extended with custom subcommands (here [`davis-fzf`](subcommands/fzf/)):
 ![screencast of davis fzf](scrots/fzf.webp)
 
 See the [manual](MANUAL.txt) for details on how to add new subcommands.
 
 ## Installing
+
 You will need a rust toolchain. To install, you run
-```
+
+```sh
 cargo install davis
 ```
 
-## Shell completions
+### Shell completions
+
 Shell completion (tab-complete) is available in `/completions`. Only bash is
 currently supported, but PRs for other shells are very welcome!

--- a/subcommands/README.md
+++ b/subcommands/README.md
@@ -1,8 +1,11 @@
 # External Subcommands
+
 Davis can be extended with external subcommands. If you have created a useful
 one, feel free to open a PR to add it to this collection!
 
-To install one of these commands, copy the relevant script to one of the following places:
+To install one of these commands, copy the relevant script to one of the
+following places:
+
 - `/etc/davis/bin/`
 - `~/.config/davis/bin/`
 - A directory in `$PATH`

--- a/subcommands/cover/README.md
+++ b/subcommands/cover/README.md
@@ -1,4 +1,5 @@
 # davis-cover
+
 `davis-cover` uses [picat](https://github.com/SimonPersson/picat) to display
 album art as high quality sixel grapics. Not every terminal supports sixels, I
 have personally tested this on xterm and [foot](https://codeberg.org/dnkl/foot).

--- a/subcommands/cur/README.md
+++ b/subcommands/cur/README.md
@@ -1,4 +1,5 @@
 # davis-cur
+
 Displays the current album art and metadata.
 
 ![davis-cur screenshot](../../scrots/cur.png)

--- a/subcommands/fzf/README.md
+++ b/subcommands/fzf/README.md
@@ -1,4 +1,5 @@
 # davis-fzf
+
 A command which uses [fzf](https://github.com/junegunn/fzf) to quickly find
 albums in the database. Launch the script with `davis fzf`, and iteratively add
 filters. Once done, press escape, and the matching albums will be added to the


### PR DESCRIPTION
Found via `markdownlint .`

See a detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md